### PR TITLE
Bring names back in sync with cloudkit-operator repository

### DIFF
--- a/base/cloudkit-aap/template-publisher.yaml
+++ b/base/cloudkit-aap/template-publisher.yaml
@@ -11,7 +11,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
-    resourceNames: ["cloudkit-controller"]
+    resourceNames: ["cloudkit-operator-controller-manager"]
     verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/base/cloudkit-operator/deployment.yaml
+++ b/base/cloudkit-operator/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: cloudkit-operator
     control-plane: controller-manager
-  name: cloudkit-controller
+  name: cloudkit-operator-controller-manager
 spec:
   replicas: 1
   selector:
@@ -70,5 +70,5 @@ spec:
                 - ALL
       securityContext:
         runAsNonRoot: true
-      serviceAccountName: cloudkit-controller
+      serviceAccountName: cloudkit-operator-controller-manager
       terminationGracePeriodSeconds: 10

--- a/base/cloudkit-operator/metrics-service.yaml
+++ b/base/cloudkit-operator/metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: cloudkit-operator
     control-plane: controller-manager
-  name: cloudkit-controller-metrics-service
+  name: cloudkit-operator-controller-manager-metrics-service
 spec:
   ports:
     - name: https

--- a/base/cloudkit-operator/rbac.yaml
+++ b/base/cloudkit-operator/rbac.yaml
@@ -61,7 +61,7 @@ roleRef:
   name: cloudkit-operator-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: cloudkit-controller
+    name: cloudkit-operator-controller-manager
     namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -118,7 +118,7 @@ roleRef:
   name: admin
 subjects:
   - kind: ServiceAccount
-    name: cloudkit-controller
+    name: cloudkit-operator-controller-manager
     namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -134,13 +134,13 @@ roleRef:
   name: cloudkit-operator-manager-role
 subjects:
   - kind: ServiceAccount
-    name: cloudkit-controller
+    name: cloudkit-operator-controller-manager
     namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cloudkit-controller
+  name: cloudkit-operator-manager-role
 rules:
   - apiGroups:
       - ''
@@ -213,7 +213,7 @@ roleRef:
   name: cloudkit-operator-metrics-auth-role
 subjects:
   - kind: ServiceAccount
-    name: cloudkit-controller
+    name: cloudkit-operator-controller-manager
     namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/base/cloudkit-operator/serviceaccount.yaml
+++ b/base/cloudkit-operator/serviceaccount.yaml
@@ -4,4 +4,4 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: cloudkit-operator
-  name: cloudkit-controller
+  name: cloudkit-operator-controller-manager

--- a/base/fulfillment-service/service/files/rules.yaml
+++ b/base/fulfillment-service/service/files/rules.yaml
@@ -42,5 +42,5 @@
     subject.name in [
       'system:serviceaccount:{{ .Env.NAMESPACE }}:fulfillment-admin',
       'system:serviceaccount:{{ .Env.NAMESPACE }}:fulfillment-controller',
-      'system:serviceaccount:{{ .Env.NAMESPACE }}:cloudkit-controller',
+      'system:serviceaccount:{{ .Env.NAMESPACE }}:cloudkit-operator-controller-manager',
     ]


### PR DESCRIPTION
Avoid confusion and future work by ensuring that service accounts,
clusteroles, etc, use the same names here as in the cloudkit-operator
repository.
