### PR TITLE
Add externalsecrets for aap license and aws/esi credentials

### DIFF
--- a/base/cloudkit-aap/cluster-fulfillment-ig-externalsecret.yaml
+++ b/base/cloudkit-aap/cluster-fulfillment-ig-externalsecret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cluster-fulfillment-ig
+spec:
+  dataFrom:
+  - extract:
+      key: /hypershift1/innabox-aws-credentials
+      conversionStrategy: Default
+      decodingStrategy: Auto
+  - extract:
+      key: /hypershift1/innabox-esi-credentials
+      conversionStrategy: Default
+      decodingStrategy: Auto
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: cluster-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: cluster-fulfillment-ig

--- a/base/cloudkit-aap/config-as-code-manifest-ig-externalsecret.yaml
+++ b/base/cloudkit-aap/config-as-code-manifest-ig-externalsecret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: config-as-code-manifest-ig
+spec:
+  dataFrom:
+  - extract:
+      conversionStrategy: Default
+      decodingStrategy: None
+      key: innabox/hypershift1/innabox-aap-license
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: cluster-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: config-as-code-manifest-ig

--- a/base/cloudkit-aap/kustomization.yaml
+++ b/base/cloudkit-aap/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
   - cloudkit-sa.yaml
   - job.yaml
   - template-publisher.yaml
+  - cluster-fulfillment-ig-externalsecret.yaml
+  - config-as-code-manifest-ig-externalsecret.yaml
 
 labels:
 - pairs:


### PR DESCRIPTION
I'm adding these to base/ right now, although I suspect that these will
ultimately move into the overlays (because different organizations manage
secrets differently, and they will *always* need to be patched to provide
the correct secret path).

