### PR TITLE
Create hub-access serviceaccount for use when creating hubs

### DIFF
--- a/base/fulfillment-service/hub-access/README.md
+++ b/base/fulfillment-service/hub-access/README.md
@@ -1,0 +1,47 @@
+The fulfillment service interacts with the target hub using the credentials you pass in when you create a hub.
+
+This directory creates a `hub-access` service account for that purposes that has read/write access to ClusterOrders in the target namespace. Any other permissions required by the fulfillment service when interacting with a hub cluster should be associated with this service account.
+
+The `hub-access` secret will be updated by Kubernetes to include a non-expiring token for the `hub-access` ServiceAccount. You can generate an appropriate `kubeconfig` file for creating a hub with the following script:
+
+```
+#!/bin/bash
+
+set -e
+
+server_url=$(
+  oc config view --minify --output jsonpath="{.clusters[*].cluster.server}"
+)
+
+server_name=${server_url#*.}
+server_name=${server_name%%.*}
+
+namespace=$(
+  oc config view --minify --output jsonpath="{.contexts[*].context.namespace}"
+)
+
+token=$(oc -n "$namespace" extract secret/hub-access --keys token --to - 2> /dev/null)
+
+echo "generating a kubeconfig for hub-access serviceaccount in $namespace namespace on $server_url"
+
+cat <<EOF > kubeconfig.hub-access
+apiVersion: v1
+clusters:
+- cluster:
+    server: "$server_url"
+  name: "$server_name"
+contexts:
+- context:
+    cluster: "$server_name"
+    namespace: "$namespace"
+    user: "system:serviceaccount:$namespace:hub-access"
+  name: "$server_name"
+current-context: "$server_name"
+kind: Config
+preferences: {}
+users:
+- name: "system:serviceaccount:$namespace:hub-access"
+  user:
+    token: "$token"
+EOF
+```

--- a/base/fulfillment-service/hub-access/kustomization.yaml
+++ b/base/fulfillment-service/hub-access/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    component: hub-access
+
+resources:
+- sa.yaml
+- rbac.yaml
+- secret.yaml

--- a/base/fulfillment-service/hub-access/rbac.yaml
+++ b/base/fulfillment-service/hub-access/rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hub-access
+rules:
+  - apiGroups:
+      - cloudkit.openshift.io
+    resources:
+      - clusterorders
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - cloudkit.openshift.io
+    resources:
+      - clusterorders/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hub-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: hub-access
+subjects:
+  - kind: ServiceAccount
+    name: hub-access
+    namespace: default

--- a/base/fulfillment-service/hub-access/sa.yaml
+++ b/base/fulfillment-service/hub-access/sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hub-access

--- a/base/fulfillment-service/hub-access/secret.yaml
+++ b/base/fulfillment-service/hub-access/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: hub-access
+  annotations:
+    kubernetes.io/service-account.name: hub-access

--- a/base/fulfillment-service/kustomization.yaml
+++ b/base/fulfillment-service/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
 - client
 - admin
 - controller
+- hub-access
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
The fulfillment service interacts with the target hub using the credentials
you pass in when you create a hub.

This commit creates a "hub-access" service account for that purposes that
has read/write access to ClusterOrders in the target namespace. Any other
permissions required by the fulfillment service when interacting with a
hub cluster should be associated with this service account.
