### PR TITLE
Add NAMESPACE var to AAP bootstrap job

### DIFF
--- a/base/cloudkit-aap/job.yaml
+++ b/base/cloudkit-aap/job.yaml
@@ -75,6 +75,10 @@ spec:
             secretKeyRef:
               name: innabox-aap-admin-password
               key: password
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
         - name: config-as-code-manifest-volume
           mountPath: /var/secrets/config-as-code-manifest


### PR DESCRIPTION
The config-as-code playbooks default `aap_prefix` like this:

    aap_prefix: "{{ lookup('env', 'AAP_PREFIX', default=aap_organization_name + '-' + aap_project_name) }}"

Where `aap_project_name` comes from:

    aap_project_name: "{{ lookup('env', 'AAP_PROJECT_NAME', default=current_namespace) }}"

And `current_namespace` comes from:

    current_namespace: "{{ lookup('env', 'NAMESPACE') }}"

Unfortunately, we weren't setting `NAMESPACE` in the bootstrap job, which
resulted in the bootstrap creating some resources in which
`aap_project_name` was empty:

    $ kubectl get service
    NAME                                                   TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
    innabox--eda-service                                   ClusterIP   172.30.78.163    <none>        5000/TCP   4m37s

But when the config-as-code job runs in AAP, `NAMESPACE` is defined, so we
get:

    $ kubectl get service
    innabox--eda-service                                   ClusterIP   172.30.78.163    <none>        5000/TCP   9m13s
    innabox-innabox-devel-eda-service                      ClusterIP   172.30.226.60    <none>        5000/TCP   32s

This also results in duplicate job templates and other resources.
