### PR TITLE
Add VMaaS base configuration with NFS storage and UDN support

### DIFF
--- a/base/cloudkit-aap/job.yaml
+++ b/base/cloudkit-aap/job.yaml
@@ -61,8 +61,6 @@ spec:
         name: bootstrap
         args:
         - ansible-playbook
-        - -vvv
-        - --diff
         - cloudkit.config_as_code.subscription
         - cloudkit.config_as_code.configure
         envFrom:

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - cloudkit-aap
   - cloudkit-operator
   - fulfillment-service
+  - vmaas
 
 # Common labels for all CloudKit components
 labels:

--- a/base/vmaas/kustomization.yaml
+++ b/base/vmaas/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+metadata:
+  name: vmaas
+
+resources:
+  - udn.yaml
+  - nfs-subdir-provisioner.yaml
+
+labels:
+- pairs:
+    cloudkit.openshift.io/project: cloudkit-vmaas
+

--- a/base/vmaas/nfs-dynamic-storageclass.yaml
+++ b/base/vmaas/nfs-dynamic-storageclass.yaml
@@ -1,0 +1,23 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs-vm-dynamic
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+    description: "Dynamic NFS storage for VM live migration with automatic provisioning"
+provisioner: nfs-subdir-external-provisioner
+parameters:
+  # Archive on delete - set to false to delete data when PVC is deleted
+  archiveOnDelete: "false"
+  # Path pattern for subdirectories: ${.PVC.namespace}-${.PVC.name}-${.PVC.uid}
+  pathPattern: "${.PVC.namespace}-${.PVC.name}"
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+mountOptions:
+  - nfsvers=4.1
+  - rsize=1048576
+  - wsize=1048576
+  - hard
+  - timeo=600
+  - retrans=2

--- a/base/vmaas/nfs-provisioner-scc.yaml
+++ b/base/vmaas/nfs-provisioner-scc.yaml
@@ -1,0 +1,33 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: nfs-provisioner-scc
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:nfs-provisioner:nfs-client-provisioner
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- nfs
+- persistentVolumeClaim
+- projected
+- secret

--- a/base/vmaas/nfs-setup.md
+++ b/base/vmaas/nfs-setup.md
@@ -1,0 +1,163 @@
+# NFS Storage Setup for VM Live Migration with OpenShift Data Foundation
+
+## Overview
+This setup provides NFS-based shared storage for OpenShift Virtualization VMs to enable live migration capabilities through OpenShift Data Foundation (ODF). VMs using this storage can be migrated between cluster nodes without downtime.
+
+## NFS Server Configuration
+
+### Server Details
+- **NFS Server IP**: 192.168.12.126
+- **Export Path**: /home/nfs
+- **Network Access**: 172.16.0.0/18 (HCP cluster network)
+- **VM Storage Size**: 25GiB per VM
+
+### Server Setup Commands
+```bash
+# Install NFS server
+sudo dnf install -y nfs-utils
+
+# Create and configure NFS directory
+sudo mkdir -p /home/nfs
+sudo chown -R nobody:nobody /home/nfs
+sudo chmod -R 777 /home/nfs
+
+# Configure exports for HCP cluster
+sudo tee /etc/exports << 'EOF'
+/home/nfs 172.16.0.0/18(rw,sync,no_subtree_check,no_root_squash)
+EOF
+
+# Start NFS services
+sudo systemctl enable --now nfs-server
+sudo exportfs -ra
+```
+
+## OpenShift Configuration with ODF
+
+### Deployment Order
+Apply the Kubernetes manifests in this order:
+
+1. **Install ODF Operator**:
+   ```bash
+   oc apply -f odf-operator.yaml
+   ```
+
+2. **Configure NFS Backend**:
+   ```bash
+   oc apply -f odf-nfs-config.yaml
+   oc apply -f nfs-storageclass.yaml
+   ```
+
+3. **Verify Deployment**:
+   ```bash
+   oc get csv -n openshift-storage
+   oc get storageclass | grep nfs
+   ```
+
+### Storage Classes Available
+- **nfs-vm-migration**: Direct NFS storage class for VM migration (25GiB)
+- **odf-nfs-vm-storage**: ODF-managed NFS storage class
+
+Both storage classes support:
+- **Access Mode**: ReadWriteMany (required for live migration)  
+- **Reclaim Policy**: Retain (data persists after PVC deletion)
+- **Volume Binding**: WaitForFirstConsumer
+- **NFS Version**: 4.1 with optimized mount options
+
+## VM Configuration
+
+### Using NFS Storage in VMs
+When creating VMs, specify the NFS storage class in DataVolume templates:
+
+```yaml
+dataVolumeTemplates:
+- metadata:
+    name: vm-disk
+  spec:
+    pvc:
+      accessModes:
+      - ReadWriteMany                    # Critical for live migration
+      resources:
+        requests:
+          storage: 25Gi                  # 25GiB storage per VM
+      storageClassName: nfs-vm-migration # Use NFS storage class
+      volumeMode: Filesystem
+```
+
+### Key Configuration Points
+- **storageClassName**: Use `nfs-vm-migration` or `odf-nfs-vm-storage`
+- **accessModes**: Must include `ReadWriteMany` for live migration
+- **storage**: Set to `25Gi` for 25GiB VM disks
+- **volumeMode**: Should be `Filesystem` for most use cases
+
+### Creating PersistentVolumes
+For each VM, create a dedicated PV:
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: vm-pv-001
+spec:
+  capacity:
+    storage: 25Gi
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nfs-vm-migration
+  nfs:
+    server: 192.168.12.126
+    path: /home/nfs/vm-001  # Unique path per VM
+```
+
+## Live Migration Benefits
+- VMs can migrate between cluster nodes without downtime
+- Shared NFS storage ensures disk data is accessible from any node
+- Enables maintenance, load balancing, and high availability scenarios
+- ODF provides additional management and monitoring capabilities
+
+## Troubleshooting
+
+### Common Issues
+1. **NFS Mount Failures**: Check network connectivity between cluster nodes and NFS server
+2. **Permission Errors**: Verify NFS exports and directory permissions  
+3. **ODF Installation**: Check operator logs in openshift-storage namespace
+4. **PV Binding**: Ensure PV paths exist on NFS server before creating PVCs
+
+### Verification Commands
+```bash
+# Test NFS connectivity from cluster nodes
+showmount -e 192.168.12.126
+
+# Check storage classes
+oc get storageclass | grep nfs
+
+# Verify ODF operator
+oc get csv -n openshift-storage
+
+# Test PVC creation
+oc create -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-nfs-pvc
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 25Gi
+  storageClassName: nfs-vm-migration
+EOF
+```
+
+### Creating VM Storage Directories
+```bash
+# Create individual directories for each VM on NFS server
+sudo mkdir -p /home/nfs/vm-001 /home/nfs/vm-002 /home/nfs/vm-003
+sudo chown -R nobody:nobody /home/nfs/vm-*
+sudo chmod -R 755 /home/nfs/vm-*
+```
+
+## Security Considerations
+- NFS exports are configured with `no_root_squash` for VM compatibility
+- Network access is restricted to HCP cluster subnet (172.16.0.0/18)
+- Each VM gets its own subdirectory for isolation
+- Consider implementing NFS security features like Kerberos for production use

--- a/base/vmaas/nfs-subdir-provisioner.yaml
+++ b/base/vmaas/nfs-subdir-provisioner.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nfs-client-provisioner
+  namespace: nfs-provisioner
+  labels:
+    app: nfs-client-provisioner
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: nfs-client-provisioner
+  template:
+    metadata:
+      labels:
+        app: nfs-client-provisioner
+    spec:
+      serviceAccountName: nfs-client-provisioner
+      containers:
+        - name: nfs-client-provisioner
+          image: registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2
+          volumeMounts:
+            - name: nfs-client-root
+              mountPath: /persistentvolumes
+          env:
+            - name: PROVISIONER_NAME
+              value: nfs-subdir-external-provisioner
+            - name: NFS_SERVER
+              value: 192.168.12.126
+            - name: NFS_PATH
+              value: /home/nfs
+      volumes:
+        - name: nfs-client-root
+          nfs:
+            server: 192.168.12.126
+            path: /home/nfs
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs-vm-dynamic
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+    description: "Dynamic NFS storage for VM live migration with automatic provisioning"
+provisioner: nfs-subdir-external-provisioner
+parameters:
+  # Archive on delete - set to false to delete data when PVC is deleted
+  archiveOnDelete: "false"
+  # Path pattern for subdirectories: ${.PVC.namespace}-${.PVC.name}-${.PVC.uid}
+  pathPattern: "${.PVC.namespace}-${.PVC.name}"
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+mountOptions:
+  - nfsvers=4.1
+  - rsize=1048576
+  - wsize=1048576
+  - hard
+  - timeo=600
+  - retrans=2
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: nfs-provisioner-scc
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:nfs-provisioner:nfs-client-provisioner
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- nfs
+- persistentVolumeClaim
+- projected
+- secret
+

--- a/base/vmaas/udn.yaml
+++ b/base/vmaas/udn.yaml
@@ -1,0 +1,38 @@
+# # Create namespace with UDN label
+# apiVersion: v1
+# kind: Namespace
+# metadata:
+#   name: vm-tenant-l2
+#   labels:
+#     k8s.ovn.org/primary-user-defined-network: ""
+#     name: vm-tenant-l2
+# ---
+# Create UserDefinedNetwork (Layer2)
+apiVersion: k8s.ovn.org/v1
+kind: UserDefinedNetwork
+metadata:
+  name: tenant-network
+  namespace: vm-tenant-l2
+spec:
+  topology: Layer2
+  layer2:
+    role: Primary
+    ipam:
+      lifecycle: Persistent
+    subnets:
+    - 10.200.0.0/16
+---
+# Create secondary UserDefinedNetwork (Layer2)
+apiVersion: k8s.ovn.org/v1
+kind: UserDefinedNetwork
+metadata:
+  name: secondary-network
+  namespace: vm-tenant-l2
+spec:
+  topology: Layer2
+  layer2:
+    role: Secondary
+    ipam:
+      lifecycle: Persistent
+    subnets:
+    - 10.100.0.0/16


### PR DESCRIPTION
## Summary
- Add VMaaS component to CloudKit installer with NFS storage and UserDefinedNetwork support
- Remove verbose flags from cloudkit-aap job for cleaner output  
- Add comprehensive NFS provisioner setup with dynamic storage class for VM live migration
- Add UserDefinedNetwork configurations for Layer2 VM networking

🤖 Generated with [Claude Code](https://claude.ai/code)